### PR TITLE
baixador de json

### DIFF
--- a/downloader/Dockerfile
+++ b/downloader/Dockerfile
@@ -1,0 +1,9 @@
+FROM python
+
+WORKDIR /app
+
+RUN pip install requests
+
+COPY main.py .
+
+ENTRYPOINT [ "python", "main.py" ]

--- a/downloader/main.py
+++ b/downloader/main.py
@@ -1,0 +1,18 @@
+import requests
+import json
+import time
+import sys
+from urllib.parse import urljoin
+
+if __name__ == "__main__":
+    while True:
+        for i in range(0, 10):
+            name = f"{sys.argv[2]}{i}"
+            print(f"working on {name}")
+            time.sleep(2)
+            with open(urljoin("/out/", f"{name}.json"), 'w+') as f:
+                json.dump(
+                    requests.get(
+                        urljoin(sys.argv[1], name),
+                        headers= {'content-type': 'application/json'}
+                    ).json(), f)


### PR DESCRIPTION
de acordo com https://github.com/marcosvpj/baleia-compositora/issues/3

dado um endereço de servidor e o nome de uma chave, ciclicamente, para indices `i` em [0, 9]:
* espera 2s
* baixa o dado json encontrado no endereço http `${SERVIDOR}:$PORTA/${CHAVE}${i}` (ex `http://localhost:3000/chave1`)
* salva esse dado como  arquivo json em `/out/${CHAVE}${i}.json` (ex `/out/chave1`)
 e se repete indefinidamente, sobrescrevendo estes 10 arquivos e mantendo-os "atualizados" com o estado no [servidor](https://github.com/marcosvpj/baleia-compositora/issues/2)

pode ser executado com
```
docker run -d --rm -v $IMAGEM 'http://localhost:3000' $CHAVE
```

mas seria interassante utilizar mapeamento de volumes (com `-v ${ONDE_COLOCAR_O_DADO}:/out`) e estando na mesma rede que o [servidor](https://github.com/marcosvpj/baleia-compositora/pull/6) (com `--network $REDE`, por exemplo)